### PR TITLE
Fix: allow null object to be sent/received

### DIFF
--- a/src/register.js
+++ b/src/register.js
@@ -8,7 +8,7 @@ const RESULT_SUCCESS = 1;
 
 const DEFAULT_HANDLER = 'main';
 
-const isPromise = o => typeof o === 'object' && typeof o.then === 'function' && typeof o.catch === 'function';
+const isPromise = o => typeof o === 'object' && o !== null && typeof o.then === 'function' && typeof o.catch === 'function';
 
 function RegisterPromise(fn) {
   const handlers = {[DEFAULT_HANDLER]: fn};

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -40,6 +40,15 @@ describe('Worker promise', () => {
 
       expect(await worker.postMessage(false)).to.be.equal(true);
     });
+  });
+  
+  describe('Mirror', () => {
+    const worker = new WorkerPromise(new Worker(path.join(__dirname, './mirror.worker.js')));
+  
+    it('null object send->receive', async () => {
+      const result = await worker.postMessage(null);
+      expect(result).to.be.equal(null);
+    });
 
   });
 

--- a/test/mirror.worker.js
+++ b/test/mirror.worker.js
@@ -1,0 +1,7 @@
+const register = require('../src/register');
+
+register(
+  (message, emit) => {
+    return message;
+  }
+);


### PR DESCRIPTION
Summary: this fixes
https://github.com/kwolfy/webworker-promise/issues/9. Null objects could
not be sent from worker to main as there was a type error raised during call to `isPromise`.

Test: added test to check that this doesn't happen anymore. Test is
available in `test/mirror.worker.js`.