### PR TITLE
WorkerPool: raising warning for invalid maxThread/maxConcurrency

### DIFF
--- a/src/pool.js
+++ b/src/pool.js
@@ -33,6 +33,10 @@ class WorkerPool {
       opts.maxConcurrentPerWorker = 1;
     }
 
+    if(!Number.isInteger(opts.maxThreads) || !Number.isInteger(opts.maxConcurrentPerWorker)){
+      console.warn('WARNING: The maxThreads and maxConcurrentPerWorker parameters should be integers equal or greater than 1');
+    }
+
     return new WorkerPool(opts);
   }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,6 +1,8 @@
 const chai = require("chai");
 const chaiAsPromised = require("chai-as-promised");
+const spies = require('chai-spies');
 chai.use(chaiAsPromised);
+chai.use(spies);
 
 const expect = chai.expect;
 
@@ -186,6 +188,26 @@ describe('Worker promise', () => {
       expect(pool._workers).to.have.length(1);
     });
 
+    it('should give warning for if maxThreads is a floating point number', async () => {
+      const spy = chai.spy.on(console, 'warn');
+      WorkerPool.create(Object.assign(opts, {
+        maxThreads: 1.5,
+        terminateAfterDelay: 100
+      }));
+
+      expect(spy).to.have.been.called.once;
+    });
+
+    it('should give warning for if maxConcurrencyPerWorker is a floating point number', async () => {
+      const spy = chai.spy.on(console, 'warn');
+      WorkerPool.create(Object.assign(opts, {
+        maxThreads: 2,
+        maxConcurrentPerWorker: 1.5,
+        terminateAfterDelay: 100
+      }));
+
+      expect(spy).to.have.been.called.once;
+    });
 
   });
 


### PR DESCRIPTION
This fixes https://github.com/kwolfy/webworker-promise/issues/13. Users will now see warning if `maxThreads`/`maxConcurrencyPerWorker` are floating point numbers. They should be both integer numbers equal or greater than one. We also added tests to check that the `console.warn` is being called.